### PR TITLE
Add -M option to clusterOptions of Cell Ranger count process

### DIFF
--- a/processes/count.nf
+++ b/processes/count.nf
@@ -37,12 +37,12 @@ def runCellRangerCount = {
 
 process SC__CELLRANGER__COUNT {
 
-	  label toolParams.labels.processExecutor
-	  cache 'deep'
-	  container toolParams.container
-	  publishDir "${params.global.outdir}/counts", mode: 'link', overwrite: true
-	  clusterOptions "-l nodes=1:ppn=${toolParams.count.ppn} -l pmem=${toolParams.count.pmem} -l walltime=${toolParams.count.walltime} -A ${params.global.qsubaccount}"
-	  maxForks = toolParams.count.maxForks
+	label toolParams.labels.processExecutor
+	cache 'deep'
+	container toolParams.container
+	publishDir "${params.global.outdir}/counts", mode: 'link', overwrite: true
+	clusterOptions "-l nodes=1:ppn=${toolParams.count.ppn} -l pmem=${toolParams.count.pmem} -l walltime=${toolParams.count.walltime} -A ${params.global.qsubaccount} -m abe -M ${params.global.qsubemail}"
+	maxForks = toolParams.count.maxForks
 
     input:
 		file(transcriptome)
@@ -68,12 +68,12 @@ process SC__CELLRANGER__COUNT {
 
 process SC__CELLRANGER__COUNT_WITH_METADATA {
 
-	  label toolParams.labels.processExecutor
-	  cache 'deep'
-	  container toolParams.container
-	  publishDir "${params.global.outdir}/counts", mode: 'link', overwrite: true
-	  clusterOptions "-l nodes=1:ppn=${toolParams.count.ppn} -l pmem=${toolParams.count.pmem} -l walltime=${toolParams.count.walltime} -A ${params.global.qsubaccount}"
-	  maxForks = toolParams.count.maxForks
+	label toolParams.labels.processExecutor
+	cache 'deep'
+	container toolParams.container
+	publishDir "${params.global.outdir}/counts", mode: 'link', overwrite: true
+	clusterOptions "-l nodes=1:ppn=${toolParams.count.ppn} -l pmem=${toolParams.count.pmem} -l walltime=${toolParams.count.walltime} -A ${params.global.qsubaccount} -m abe -M ${params.global.qsubemail}"
+	maxForks = toolParams.count.maxForks
 
     input:
 		tuple \

--- a/workflows/cellRangerCountWithMetadata.nf
+++ b/workflows/cellRangerCountWithMetadata.nf
@@ -30,7 +30,7 @@ workflow CELLRANGER_COUNT_WITH_METADATA {
                 // Begin CellRanger parameters
                 row.expect_cells
             )
-        }.view()
+        }
         SC__CELLRANGER__COUNT_WITH_METADATA( data )
 
     emit:


### PR DESCRIPTION
This is usefull to get job status (job has started or finished) by email since this process is quite computationally expensive